### PR TITLE
Don’t move points with no mass

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -36,9 +36,15 @@ module.exports = function(vec) {
             scalarP2
 
         //handle zero mass a little differently
-        if (p1mass===0||p2mass===0) {
-            scalarP1 = this.stiffness
+        if (p1mass == 0 && p2mass == 0) {
+            scalarP1 = 0
+            scalarP2 = 0
+        } else if (p1mass == 0 && p2mass > 0) {
+            scalarP1 = 0
             scalarP2 = this.stiffness
+        } else if (p1mass > 0 && p2mass == 0) {
+            scalarP1 = this.stiffness
+            scalarP2 = 0
         } else {
             //invert mass quantities
             var im1 = 1.0 / p1mass


### PR DESCRIPTION
Trying to fix https://github.com/mattdesl/verlet-constraint/issues/1 and https://github.com/mattdesl/verlet-system/issues/1

Before
![dna-old](https://cloud.githubusercontent.com/assets/171001/17848600/40461d74-684c-11e6-9d2f-f27ea91c2fee.gif)

After
![dna](https://cloud.githubusercontent.com/assets/171001/17848603/41a1db36-684c-11e6-8f51-e8b070c0e33d.gif)
